### PR TITLE
ROMs: Add nlos.

### DIFF
--- a/supported_roms.xml
+++ b/supported_roms.xml
@@ -42,6 +42,7 @@
     <rom name="madOS" id="ro.mados.version" />
     <rom name="Mokee" id="ro.mk.version" />
     <rom name="Nitrogen-OS" id="ro.nitrogen.version" />
+    <rom name="NLOS" id="ro.nlos.version" />
     <rom name="noobbuilds" id="ro.noob.version" />
     <rom name="NucleaROM" id="ro.nuclear.version" />
     <rom name="OctOS" id="ro.to.version" />


### PR DESCRIPTION
I've added
ro.nlos.version=nlos-15.1
to build prop:
https://github.com/nvertigo/android_device_oneplus_oneplus3t/commit/c68f781d0cff2f76b5320ea78f024a88e4956e2e